### PR TITLE
Purge cache on trash

### DIFF
--- a/includes/class-akamai.php
+++ b/includes/class-akamai.php
@@ -137,6 +137,7 @@ class Akamai {
 
 		// Purging Actions/Hooks
 		$this->loader->add_action( 'save_post', $this, 'purgeOnPost' );
+		$this->loader->add_action( 'wp_trash_post', $this, 'purgeOnPost' );
 		$this->loader->add_action( 'comment_post', $this, 'purgeOnPost', 10, 3 );
 		$this->loader->add_action( 'admin_notices', $this, 'admin_notices' );
 		$this->loader->add_action( 'send_headers', $this, 'sendHeaders' );


### PR DESCRIPTION
Akamai needs to purge cache upon post deletion and post_save hook is not enough to do that. Because post_save happens after the update and then in the purgeOnPost function we have a condition to not purge if the post is not published.
`if ( ! is_object( $post ) || $post->post_status != 'publish' ) {
			return true;
		}`
wp_trash_post happens before trashing and it will fix the problem.