### PR TITLE
Add a filter to modify the array of urls to be purged

### DIFF
--- a/includes/class-akamai.php
+++ b/includes/class-akamai.php
@@ -264,7 +264,7 @@ class Akamai {
 
 		$data = array(
 			'hostname' => $host,
-			'objects'  => $objects
+			'objects'  => apply_filters( 'wp_akamai_purge_objects ', $objects, $options, $post )
 		);
 
 		return json_encode( $data );

--- a/includes/class-akamai.php
+++ b/includes/class-akamai.php
@@ -264,7 +264,7 @@ class Akamai {
 
 		$data = array(
 			'hostname' => $host,
-			'objects'  => apply_filters( 'wp_akamai_purge_objects ', $objects, $options, $post )
+			'objects'  => apply_filters( 'wp_akamai_purge_objects', $objects, $options, $post )
 		);
 
 		return json_encode( $data );


### PR DESCRIPTION
When the akamai cache is purged, it may be beneficial to purge other pages — custom post archived, custom taxonomy archives, etc. Adding a filter opens up the capability for developers to customize what gets purged without having to add additional options to the plugin UI.